### PR TITLE
fix: failed datetime values were raising json error

### DIFF
--- a/validoopsie/validation_catalogue/DateValidation/column_match_date_format.py
+++ b/validoopsie/validation_catalogue/DateValidation/column_match_date_format.py
@@ -93,7 +93,7 @@ class ColumnMatchDateFormat(BaseValidation):
         return (
             frame.with_columns(exp)
             .filter(nw.col("contains") == False)
-            .select(nw.col(self.column))
+            .select(nw.col(self.column).cast(nw.String))
             .group_by(self.column)
             .agg(nw.col(self.column).count().alias(f"{self.column}-count"))
         )

--- a/validoopsie/validation_catalogue/DateValidation/date_to_be_between.py
+++ b/validoopsie/validation_catalogue/DateValidation/date_to_be_between.py
@@ -96,4 +96,5 @@ class DateToBeBetween(BaseValidation):
             )
             .group_by(self.column)
             .agg(nw.col(self.column).count().alias(f"{self.column}-count"))
+            .with_columns(nw.col(self.column).cast(nw.String).alias(self.column))
         )


### PR DESCRIPTION
If the column was of format datetime the json output at `raise_results` was failing. This fixes the issue, however, does loose the initial column datatype.