### PR TITLE
docs: add comprehensive __call__ docstrings across all validators

### DIFF
--- a/validoopsie/validation_catalogue/DateValidation/column_match_date_format.py
+++ b/validoopsie/validation_catalogue/DateValidation/column_match_date_format.py
@@ -74,7 +74,13 @@ class ColumnMatchDateFormat(BaseValidation):
         return f"The column '{self.column}' has unique values that are not in the list."
 
     def __call__(self, frame: Frame) -> Frame:
-        """Check if the values in a column match the date format."""
+        """Check if the values in a column match the date format.
+
+        Args:
+            frame (Frame): Input data frame to validate.
+
+        Returns:
+            Frame: Data frame with the validation results attached."""
         date_patterns = re.findall(r"[Ymd]+", self.date_format)
         separators = re.findall(r"[^Ymd]+", self.date_format)
 

--- a/validoopsie/validation_catalogue/DateValidation/date_to_be_between.py
+++ b/validoopsie/validation_catalogue/DateValidation/date_to_be_between.py
@@ -86,7 +86,13 @@ class DateToBeBetween(BaseValidation):
         )
 
     def __call__(self, frame: Frame) -> Frame:
-        """Check if the string lengths are between the specified range."""
+        """Check if the string lengths are between the specified range.
+
+        Args:
+            frame (Frame): Input data frame to validate.
+
+        Returns:
+            Frame: Data frame with the validation results attached."""
         return (
             min_max_filter(
                 frame,

--- a/validoopsie/validation_catalogue/EqualityValidation/pair_column_equality.py
+++ b/validoopsie/validation_catalogue/EqualityValidation/pair_column_equality.py
@@ -71,7 +71,13 @@ class PairColumnEquality(BaseValidation):
         )
 
     def __call__(self, frame: Frame) -> Frame:
-        """Check if the pair of columns are equal."""
+        """Check if the pair of columns are equal.
+
+        Args:
+            frame (Frame): Input data frame to validate.
+
+        Returns:
+            Frame: Data frame with the validation results attached."""
         select_columns = [self.column, f"{self.column}-count"]
         gb_cols = (
             [self.column, self.target_column] if self.group_by_combined else [self.column]

--- a/validoopsie/validation_catalogue/NullValidation/column_be_null.py
+++ b/validoopsie/validation_catalogue/NullValidation/column_be_null.py
@@ -58,7 +58,13 @@ class ColumnBeNull(BaseValidation):
         return f"The column '{self.column}' doesn't have values that are null."
 
     def __call__(self, frame: Frame) -> Frame:
-        """Check if the values in a column are null."""
+        """Check if the values in a column are null.
+
+        Args:
+            frame (Frame): Input data frame to validate.
+
+        Returns:
+            Frame: Data frame with the validation results attached."""
         return (
             frame.select(self.column)
             .filter(

--- a/validoopsie/validation_catalogue/NullValidation/column_not_be_null.py
+++ b/validoopsie/validation_catalogue/NullValidation/column_not_be_null.py
@@ -58,7 +58,13 @@ class ColumnNotBeNull(BaseValidation):
         return f"The column '{self.column}' has values that are null."
 
     def __call__(self, frame: Frame) -> Frame:
-        """Check if the values in a column are not null."""
+        """Check if the values in a column are not null.
+
+        Args:
+            frame (Frame): Input data frame to validate.
+
+        Returns:
+            Frame: Data frame with the validation results attached."""
         null_count_col = f"{self.column}-count"
         return (
             frame.filter(

--- a/validoopsie/validation_catalogue/StringValidation/length_to_be_between.py
+++ b/validoopsie/validation_catalogue/StringValidation/length_to_be_between.py
@@ -80,7 +80,13 @@ class LengthToBeBetween(BaseValidation):
         )
 
     def __call__(self, frame: Frame) -> Frame:
-        """Check if the string lengths are between the specified range."""
+        """Check if the string lengths are between the specified range.
+
+        Args:
+            frame (Frame): Input data frame to validate.
+
+        Returns:
+            Frame: Data frame with the validation results attached."""
         transformed_frame = frame.with_columns(
             nw.col(self.column).str.len_chars().alias(f"{self.column}-length"),
         )

--- a/validoopsie/validation_catalogue/StringValidation/length_to_be_equal_to.py
+++ b/validoopsie/validation_catalogue/StringValidation/length_to_be_equal_to.py
@@ -66,7 +66,13 @@ class LengthToBeEqualTo(BaseValidation):
         )
 
     def __call__(self, frame: Frame) -> Frame:
-        """Expect the column entries to be strings with length equal to `value`."""
+        """Expect the column entries to be strings with length equal to `value`.
+
+        Args:
+            frame (Frame): Input data frame to validate.
+
+        Returns:
+            Frame: Data frame with the validation results attached."""
         return (
             frame.filter(
                 nw.col(self.column).str.len_chars() != self.value,

--- a/validoopsie/validation_catalogue/StringValidation/not_pattern_match.py
+++ b/validoopsie/validation_catalogue/StringValidation/not_pattern_match.py
@@ -66,7 +66,13 @@ class NotPatternMatch(BaseValidation):
         )
 
     def __call__(self, frame: Frame) -> Frame:
-        """Expect the column entries to be strings that do not pattern match."""
+        """Expect the column entries to be strings that do not pattern match.
+
+        Args:
+            frame (Frame): Input data frame to validate.
+
+        Returns:
+            Frame: Data frame with the validation results attached."""
         return (
             frame.filter(
                 nw.col(self.column).cast(nw.String).str.contains(self.pattern) == True,

--- a/validoopsie/validation_catalogue/StringValidation/pattern_match.py
+++ b/validoopsie/validation_catalogue/StringValidation/pattern_match.py
@@ -66,7 +66,13 @@ class PatternMatch(BaseValidation):
         )
 
     def __call__(self, frame: Frame) -> Frame:
-        """Expect the column entries to be strings that pattern matches."""
+        """Expect the column entries to be strings that pattern matches.
+
+        Args:
+            frame (Frame): Input data frame to validate.
+
+        Returns:
+            Frame: Data frame with the validation results attached."""
         return (
             frame.filter(
                 nw.col(self.column).cast(nw.String).str.contains(self.pattern) == False,

--- a/validoopsie/validation_catalogue/TypeValidation/type_check.py
+++ b/validoopsie/validation_catalogue/TypeValidation/type_check.py
@@ -112,7 +112,13 @@ class TypeCheck(BaseValidation):
         )
 
     def __call__(self, frame: Frame) -> dict:
-        """Validate the data type of the column(s)."""
+        """Validate the data type of the column(s).
+
+        Args:
+            frame (Frame): Input data frame to validate.
+
+        Returns:
+            Frame: Data frame with the validation results attached."""
         schema = frame.collect_schema()
         # Introduction of a new structure where the schema len will be used a frame length
         self.schema_length = schema.len()

--- a/validoopsie/validation_catalogue/UniqueValidation/column_unique_pair.py
+++ b/validoopsie/validation_catalogue/UniqueValidation/column_unique_pair.py
@@ -72,7 +72,13 @@ class ColumnUniquePair(BaseValidation):
         )
 
     def __call__(self, frame: Frame) -> Frame:
-        """Check if the unique values are in the list."""
+        """Check if the unique values are in the list.
+
+        Args:
+            frame (Frame): Input data frame to validate.
+
+        Returns:
+            Frame: Data frame with the validation results attached."""
         return (
             frame.with_columns(
                 nw.concat_str(

--- a/validoopsie/validation_catalogue/UniqueValidation/column_unique_value_count_to_be_between.py
+++ b/validoopsie/validation_catalogue/UniqueValidation/column_unique_value_count_to_be_between.py
@@ -79,7 +79,13 @@ class ColumnUniqueValueCountToBeBetween(BaseValidation):
         )
 
     def __call__(self, frame: Frame) -> Frame:
-        """Validate the number of unique values in the column."""
+        """Validate the number of unique values in the column.
+
+        Args:
+            frame (Frame): Input data frame to validate.
+
+        Returns:
+            Frame: Data frame with the validation results attached."""
         unique_value_counts = frame.group_by(self.column).agg(
             nw.col(self.column).count().alias(f"{self.column}-count"),
         )

--- a/validoopsie/validation_catalogue/UniqueValidation/column_unique_values_to_be_in_list.py
+++ b/validoopsie/validation_catalogue/UniqueValidation/column_unique_values_to_be_in_list.py
@@ -63,7 +63,13 @@ class ColumnUniqueValuesToBeInList(BaseValidation):
         return f"The column '{self.column}' has unique values that are not in the list."
 
     def __call__(self, frame: Frame) -> Frame:
-        """Check if the unique values are in the list."""
+        """Check if the unique values are in the list.
+
+        Args:
+            frame (Frame): Input data frame to validate.
+
+        Returns:
+            Frame: Data frame with the validation results attached."""
         return (
             frame.group_by(self.column)
             .agg(nw.col(self.column).count().alias(f"{self.column}-count"))

--- a/validoopsie/validation_catalogue/ValuesValidation/column_values_to_be_between.py
+++ b/validoopsie/validation_catalogue/ValuesValidation/column_values_to_be_between.py
@@ -80,7 +80,13 @@ class ColumnValuesToBeBetween(BaseValidation):
         )
 
     def __call__(self, frame: Frame) -> Frame:
-        """Check if the values in a column are between a range."""
+        """Check if the values in a column are between a range.
+
+        Args:
+            frame (Frame): Input data frame to validate.
+
+        Returns:
+            Frame: Data frame with the validation results attached."""
         return (
             min_max_filter(
                 frame,

--- a/validoopsie/validation_catalogue/ValuesValidation/columns_sum_to_be_between.py
+++ b/validoopsie/validation_catalogue/ValuesValidation/columns_sum_to_be_between.py
@@ -85,7 +85,13 @@ class ColumnsSumToBeBetween(BaseValidation):
         )
 
     def __call__(self, frame: Frame) -> Frame:
-        """Check if the sum of columns is greater than or equal to `max_sum`."""
+        """Check if the sum of columns is greater than or equal to `max_sum`.
+
+        Args:
+            frame (Frame): Input data frame to validate.
+
+        Returns:
+            Frame: Data frame with the validation results attached."""
         # This is just in case if there is some weird column name, such as "sum"
         col_name = "-".join(self.columns_list) + "-sum"
         summed_frame = frame.select(self.columns_list).with_columns(

--- a/validoopsie/validation_catalogue/ValuesValidation/columns_sum_to_be_equal_to.py
+++ b/validoopsie/validation_catalogue/ValuesValidation/columns_sum_to_be_equal_to.py
@@ -67,7 +67,13 @@ class ColumnsSumToBeEqualTo(BaseValidation):
         return f"The columns {self.columns_list} do not sum to {self.sum_value}."
 
     def __call__(self, frame: Frame) -> Frame:
-        """Check if the sum of the columns is equal to a specific value."""
+        """Check if the sum of the columns is equal to a specific value.
+
+        Args:
+            frame (Frame): Input data frame to validate.
+
+        Returns:
+            Frame: Data frame with the validation results attached."""
         # This is just in case if there is some weird column name, such as "sum"
         col_name = "-".join(self.columns_list) + "-sum"
         return (


### PR DESCRIPTION
Complement one-line __call__ docstrings across all 16 validators with structured Args (frame) and Returns documentation.

Motivation: API docs render from docstrings via mkdocstrings; __call__ is the invocation surface but had single-sentence docstrings.

Changes: 16 files under validoopsie/validation_catalogue/; docstring-only (+112/-16); no behavior change.

Testing: python -m py_compile passes; docstring-only change.